### PR TITLE
Remove some allocation from Count and Measure

### DIFF
--- a/statsd_test.go
+++ b/statsd_test.go
@@ -11,7 +11,7 @@ import (
 func NewTestClient(prefix string) (Stater, *bytes.Buffer) {
 	b := &bytes.Buffer{}
 	buf := bufio.NewReadWriter(bufio.NewReader(b), bufio.NewWriter(b))
-	c := &RemoteClient{buf: buf, prefix: prefix}
+	c := &RemoteClient{buf: buf, prefix: []byte(prefix)}
 	return c, b
 }
 


### PR DESCRIPTION
@mlerner 

```
benchmark                          old ns/op     new ns/op     delta
BenchmarkCountMultiple             749           386           -48.46%
BenchmarkCountMultipleWithRate     1786          684           -61.70%
BenchmarkMeasure                   754           379           -49.73%
BenchmarkMeasureWithRate           1782          687           -61.45%

benchmark                          old allocs     new allocs     delta
BenchmarkCountMultiple             5              1              -80.00%
BenchmarkCountMultipleWithRate     9              2              -77.78%
BenchmarkMeasure                   5              1              -80.00%
BenchmarkMeasureWithRate           9              2              -77.78%

benchmark                          old bytes     new bytes     delta
BenchmarkCountMultiple             139           101           -27.34%
BenchmarkCountMultipleWithRate     233           133           -42.92%
BenchmarkMeasure                   140           103           -26.43%
BenchmarkMeasureWithRate           235           135           -42.55%
```