### PR TITLE
Allow Substaters to just use the same prefix, ie. no additional

### DIFF
--- a/statsd_test.go
+++ b/statsd_test.go
@@ -137,6 +137,12 @@ func TestSubstater(t *testing.T) {
 	if p := c2.prefix; string(p) != "prefix.extra" {
 		t.Errorf("incorrect prefix, got %v", string(p))
 	}
+
+	// without a prefix
+	c2 = c.Substater()
+	if p := c2.prefix; string(p) != "prefix" {
+		t.Errorf("incorrect prefix, got %v", string(p))
+	}
 }
 
 func TestCount(t *testing.T) {


### PR DESCRIPTION
This is to allow clients to use the same connection but different DefaultRates. FYI @mlerner 